### PR TITLE
Support for nested field types

### DIFF
--- a/objectfactory/__init__.py
+++ b/objectfactory/__init__.py
@@ -6,4 +6,4 @@ from .serializable import Serializable, Field
 from .factory import Factory
 from .field import Nested, List
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'

--- a/objectfactory/serializable.py
+++ b/objectfactory/serializable.py
@@ -16,10 +16,11 @@ class Field( object ):
     serializable objects
     """
 
-    def __init__( self, default=None, name=None ):
+    def __init__( self, default=None, name=None, field_type=None ):
         self._name = name
         self._key = None  # note: this will be set from parent metaclass __new__
         self._default = default
+        self._field_type = field_type
 
     def __get__( self, instance, owner ):
         return getattr( instance, self._key, self._default )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open( 'README.md', 'r' ) as fh:
 
 setuptools.setup(
     name='objectfactory',
-    version='0.0.2',
+    version='0.0.3',
     author='Devin A. Conley',
     author_email='devinaconley@gmail.com',
     description='A python package for the serializable model / factory pattern',


### PR DESCRIPTION
- allow setting class type for serializable `Nested` field
- allow setting class type for nested serializable `List`
- will automatically use this class if `_type` is not specified in dictionary
- will throw error if conflicting `_type` is provided
- bump to `0.0.3`